### PR TITLE
&'input str を String に置き換える

### DIFF
--- a/src/typedef.rs
+++ b/src/typedef.rs
@@ -1,85 +1,85 @@
 //! type definition of AST.
 
 #[derive(Debug, PartialEq)]
-pub struct Row<'a> {
+pub struct Row {
     pub breaks: Option<()>,
-    pub content: Option<ReservedControl<'a>>,
-    pub comment_trailing: Option<Comment<'a>>,
+    pub content: Option<ReservedControl>,
+    pub comment_trailing: Option<Comment>,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Comment<'a>(pub &'a str);
+pub struct Comment(pub String);
 
 /// reserved controls
 #[derive(Debug, PartialEq)]
-pub enum ReservedControl<'a> {
-    Call(Call<'a>),
-    WaitSec(WaitSec<'a>),
-    WaitUntil(WaitUntil<'a>),
-    CheckValue(CheckValue<'a>),
-    Command(Command<'a>),
-    Let(Let<'a>),
-    Get(Get<'a>),
+pub enum ReservedControl {
+    Call(Call),
+    WaitSec(WaitSec),
+    WaitUntil(WaitUntil),
+    CheckValue(CheckValue),
+    Command(Command),
+    Let(Let),
+    Get(Get),
 }
 
 #[derive(Debug, PartialEq)]
-pub struct VariablePath<'a> {
-    pub raw: &'a str,
+pub struct VariablePath {
+    pub raw: String,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct FilePath<'a> {
-    pub full_name: &'a str,
+pub struct FilePath {
+    pub full_name: String,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct CheckValue<'a> {
-    pub condition: Expr<'a>,
+pub struct CheckValue {
+    pub condition: Expr,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Command<'a> {
-    pub destinations: Vec<Destination<'a>>,
-    pub name: &'a str,
-    pub args: Vec<Expr<'a>>,
+pub struct Command {
+    pub destinations: Vec<Destination>,
+    pub name: String,
+    pub args: Vec<Expr>,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Destination<'a> {
-    pub component: &'a str,
-    pub exec_method: &'a str,
+pub struct Destination {
+    pub component: String,
+    pub exec_method: String,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Call<'a> {
-    pub path: FilePath<'a>,
+pub struct Call {
+    pub path: FilePath,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct WaitSec<'a> {
-    pub sec: Expr<'a>,
+pub struct WaitSec {
+    pub sec: Expr,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct WaitUntil<'a> {
-    pub condition: Expr<'a>,
+pub struct WaitUntil {
+    pub condition: Expr,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct WaitInc<'a> {
-    pub condition: Expr<'a>,
+pub struct WaitInc {
+    pub condition: Expr,
 }
 
 #[derive(Debug, PartialEq)]
-pub enum CompareOp<'a> {
-    BinOp(CompareBinOp<'a>),
-    In(CompareIn<'a>),
+pub enum CompareOp {
+    BinOp(CompareBinOp),
+    In(CompareIn),
 }
 
 #[derive(Debug, PartialEq)]
-pub struct CompareBinOp<'a> {
+pub struct CompareBinOp {
     pub method: CompareBinOpKind,
-    pub rhs: Expr<'a>,
+    pub rhs: Expr,
 }
 
 #[derive(Debug, PartialEq)]
@@ -93,50 +93,50 @@ pub enum CompareBinOpKind {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct CompareIn<'a> {
-    pub lo: Expr<'a>,
-    pub hi: Expr<'a>,
+pub struct CompareIn {
+    pub lo: Expr,
+    pub hi: Expr,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Ident<'a> {
-    pub raw: &'a str,
+pub struct Ident {
+    pub raw: String,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Let<'a> {
-    pub variable: Ident<'a>,
-    pub rhs: Expr<'a>,
+pub struct Let {
+    pub variable: Ident,
+    pub rhs: Expr,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Get<'a> {
-    pub variable: VariablePath<'a>,
+pub struct Get {
+    pub variable: VariablePath,
 }
 
 /// an expression.
 ///
 /// to implementer: you can use stack machine to express the evaluation of this tree structure.
 #[derive(Debug, PartialEq)]
-pub enum Expr<'a> {
-    Variable(VariablePath<'a>),
-    Literal(Literal<'a>),
+pub enum Expr {
+    Variable(VariablePath),
+    Literal(Literal),
     UnOp(UnOpKind, Box<Self>),
     BinOp(BinOpKind, Box<Self>, Box<Self>),
     FunCall(Box<Self>, Vec<Self>),
 }
 
 #[derive(Debug, PartialEq)]
-pub enum Literal<'a> {
-    Array(Vec<Expr<'a>>),
-    String(&'a str),
-    Numeric(Numeric<'a>, Option<NumericSuffix>),
+pub enum Literal {
+    Array(Vec<Expr>),
+    String(String),
+    Numeric(Numeric, Option<NumericSuffix>),
 }
 
 #[derive(Debug, PartialEq)]
-pub enum Numeric<'a> {
-    Integer(&'a str, IntegerPrefix),
-    Float(&'a str),
+pub enum Numeric {
+    Integer(String, IntegerPrefix),
+    Float(String),
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
現在のところ一行分の文字列をパースして即座に解釈するような使い方しかしていない
しかし今後複数行にブロック構文を導入する場合そのような方法はとれないから、コード全体をパースした結果のASTを呼び出し元に返すことも必要になる。
wasmでのinteroperationを考えると返り値の型にlifetime parameterは存在してほしくない。

ということでいったん&'input str は Stringにする
パフォーマンス上問題になったらinterningなり、元のコードに対する位置情報なりに置き換える